### PR TITLE
bump dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "ndarray": "^1.0.13",
-    "cwise-compiler": "^0.1.0"
+    "cwise-compiler": "^1.1.2",
+    "ndarray": "^1.0.13"
   },
   "devDependencies": {
     "tap": "~0.4.2",


### PR DESCRIPTION
Bump cwise to latest version. The tests pass but I'm not sure whether this introduces any other problems.

Currently `static-kdtree` (>70kb bundled) has two versions of `cwise-compiler` in its dependency tree that will not dedupe due to version conflicts. This shaves about 7kb after minifcation, which is a small step toward reducing `static-kdtree` (compare with the `kdt` npm module, which bundles to 4kb). 
