### PR TITLE
changed 'instanceof Array' to 'Array.isArray' because instanceof can …

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -5,7 +5,7 @@ var do_convert = require("./doConvert.js")
 
 module.exports = function convert(arr, result) {
   var shape = [], c = arr, sz = 1
-  while(c instanceof Array) {
+  while(Array.isArray(c)) {
     shape.push(c.length)
     sz *= c.length
     c = c[0]


### PR DESCRIPTION
…only validate Arrays created in the same memory frame/window

Hi, this was kind of a unique bug to debug, but basically the package doesn't work in its current form (at least on node v6.3.0) because the typecheck would always return false on `while c instanceof Array`, meaning the execution block would jump to line 14 with an empty shape array and break with this error:

```
TypeError: ctor is not a function
    at wrappedNDArrayCtor (/Users/kamal/Projects/opensource/ndarray-pack/node_modules/ndarray/ndarray.js:311:12)
    at convert (/Users/kamal/Projects/opensource/ndarray-pack/convert.js:14:12)
    at repl:1:1
    at sigintHandlersWrap (vm.js:32:31)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInContext (vm.js:31:12)
    at REPLServer.defaultEval (repl.js:308:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:489:10)
```

The unit-tests run fine, so it took me a minute to figure out the problem, but our good friend Douglas Crockford has already devised the problem:  http://javascript.crockford.com/remedial.html

Of interest is "The typeOf function above will only recognize arrays that are created in the same context (or window or frame). If we want to recognize arrays that are constructed in a different frame, then we need to do something more complicated."  I believe his manual approach is due to writing in ES3, but as of ES5 we are given `Array.isArray`.

As per StackOverflow: http://stackoverflow.com/questions/767486/how-do-you-check-if-a-variable-is-an-array-in-javascript/767499#767499 , `Array.isArray` is the slowest option, but the other approaches seem to have the same limitations as `instanceof` regarding frame/context.

Specifically:

``` javascript
c.constructor === Array
c.constructor == Array
c.constructor === Array.prototype.constructor
c instanceof Array
```

all return `false`.

Since the conversion is a one-time event in the packing of the nested Array, for each call of `ndarray-pack` I believe going with the clear and robust solution `Array.isArray` versus something like `Object.prototype.toString.call(c)` is the ideal solution.

I'm not entirely sure how to test passing in a nested Array from a different memory context, so there are no additional tests.

Anyway, I hope you agree with the contribution!

Thanks,
Kamal
